### PR TITLE
Fixed typo on resources for users in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  resource :users do
+  resources :users do
     resources :rentals, only: [:index]
     resources :cars do
       resources :rentals, only: [:index]


### PR DESCRIPTION
changed "resource" to "resources" for :users

resources nested for users are now unique to their Id (can also just use devise current_user). 